### PR TITLE
Add support for specifying the P4USER, P4CLIENT etc variables in the sublime Perforce.sublime-settings

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -65,6 +65,8 @@ def getPerforceConfigFromPreferences(command):
     def addP4Var(command, var):
         p4var = perforce_settings.get(var)
         if p4var:
+            if sublime.platform() == "windows":
+                return command + "SET " + var + "=" + p4var + " && "
             return command + var + "=" + p4var + " "
         return command
     command = addP4Var(command, "P4PORT")

--- a/Perforce.py
+++ b/Perforce.py
@@ -52,7 +52,25 @@ def ConstructCommand(in_command):
     command = ''
     if(sublime.platform() == "osx"):
         command = 'source ~/.bash_profile && '
+    command = getPerforceConfigFromPreferences(command)
     command += in_command
+    return command
+
+def getPerforceConfigFromPreferences(command):
+    perforce_settings = sublime.load_settings('Perforce.sublime-settings')
+
+    # check to see if the sublime preferences include the given p4 config
+    # if it does, then add it to the command in the form "var=value command"
+    # so that they get inserted into the environment the command runs in
+    def addP4Var(command, var):
+        p4var = perforce_settings.get(var)
+        if p4var:
+            return command + var + "=" + p4var + " "
+        return command
+    command = addP4Var(command, "P4PORT")
+    command = addP4Var(command, "P4CLIENT")
+    command = addP4Var(command, "P4USER")
+    command = addP4Var(command, "P4PASSWD")
     return command
 
 def GetUserFromClientspec():


### PR DESCRIPTION
If you put things like
    "P4PORT": "perforceserver.com:1666",
    "P4CLIENT": "Seb.client",
    "P4USER": "seb",
    "P4PASSWD": "password"

in the perforce sublime preferences file, the p4 info command succeeds. I was having issues with getting it to pick up my config environment variables on Linux and this should also allow people on Windows with registry issues to fix them.
