### PR TITLE
Add support for null client root and non-default changelist descriptions

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -142,6 +142,8 @@ def IsFolderUnderClientRoot(in_folder):
         return 0
 
     clientroot = clientroot.lower()
+    if(clientroot == "null"):
+        return 1
 
     # convert all paths to "os.sep" slashes 
     convertedfolder = in_folder.lower().replace('\\', os.sep).replace('/', os.sep);
@@ -580,6 +582,9 @@ class ListCheckedOutFilesThread(threading.Thread):
         clientroot = GetClientRoot(os.path.dirname(in_filename))
         if(clientroot == -1):
             return 0
+
+        if(clientroot == "null"):
+            return in_filename
 
         filename = clientroot + os.sep + in_filename.replace('\\', os.sep).replace('/', os.sep)
 

--- a/Perforce.py
+++ b/Perforce.py
@@ -675,7 +675,10 @@ def CreateChangelist(description):
         return 0, err
 
     # Find the description field and modify it
-    result = result.replace("<enter description here>", description)
+    desclabel = 'Description:' + os.linesep
+    descindex = result.find(desclabel) + len(desclabel)
+    descend = result.find(os.linesep*2, descindex)
+    result = result[0:descindex] + '\t' + description + result[descend:]
 
     # Remove all files from the query, we want them to stay in Default
     filesindex = result.rfind("Files:")


### PR DESCRIPTION
We have the Perforce server supply a changelist description template for certain users. Matching the default of "&lt;enter description here&gt;" does not work in those cases.
