### PR TITLE
Not having a .bash_profile file shouldn't silently break this plugin

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -52,7 +52,7 @@ perforceplugin_dir = os.getcwdu()
 # Utility functions
 def ConstructCommand(in_command):
     command = ''
-    if(sublime.platform() == "osx"):
+    if(sublime.platform() == "osx" and os.path.exists('~/.bash_profile')):
         command = 'source ~/.bash_profile && '
     # Revert change until threading is fixed
     # command = getPerforceConfigFromPreferences(command)


### PR DESCRIPTION
Great Plugin. I just installed it and it was silently failing. The cause was that I don't have a .bash_profile on this machine (osx).
