### PR TITLE
Adding plugin option to override .bash_profile sourcing

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -51,12 +51,17 @@ perforceplugin_dir = os.getcwdu()
 
 # Utility functions
 def ConstructCommand(in_command):
+    perforce_settings = sublime.load_settings('Perforce.sublime-settings')
+    p4Env = perforce_settings.get('P4ENV')
     command = ''
-    if(sublime.platform() == "osx"):
+    if(p4Env and p4Env != ''):
+        command = 'source ' + p4Env + ' && '
+    elif(sublime.platform() == "osx"):
         command = 'source ~/.bash_profile && '
     # Revert change until threading is fixed
     # command = getPerforceConfigFromPreferences(command)
-    command += in_command
+    command += in_command + ' && p4 tickets'
+    LogResults(True, command)
     return command
 
 def getPerforceConfigFromPreferences(command):


### PR DESCRIPTION
This change allows a user to specify an alternate file to source, such as ~/.p4env
