### PR TITLE
Set the global command_prefix correctly

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -54,6 +54,7 @@ command_prefix = ""
 def PrepareCommand():
     perforce_settings = sublime.load_settings('Perforce.sublime-settings')
     p4Env = perforce_settings.get('perforce_p4env')
+    global command_prefix
     command_prefix = ''
     if(p4Env and p4Env != ''):
         command_prefix = 'source ' + p4Env + ' && '


### PR DESCRIPTION
Without the added line, PrepareCommand() only sets a local command_prefix variable, causing p4 errors when p4 is not on the default path. (In my case, it's at /usr/local/bin/p4).
