### PR TITLE
Hiding users password for the Login Input Password box

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -997,8 +997,24 @@ class PerforceLogoutCommand(sublime_plugin.WindowCommand):
             pass
 
 class PerforceLoginCommand(sublime_plugin.WindowCommand):
+    pwd = ""
+
     def run(self):
-        self.window.show_input_panel("Enter Perforce Password", "", self.on_done, None, None)
+        self.window.show_input_panel("Enter Perforce Password", "", self.on_done, self.getpwd, None)
+
+    def getpwd(self, password):
+        chg = password.replace("*", "")
+        if  len(password) < len(self.pwd):
+            self.pwd = self.pwd[:len(password)]
+        else:
+            self.pwd = self.pwd + chg
+        stars = "*" * len(password)
+        self.window.show_input_panel("Project name", stars, self.on_input, self.getpwd, None)
+
+    def on_input(self, password):
+        if self.pwd.strip() == "":
+            self.panel("No password provided")
+            return
 
     def on_done(self, password):
         try:

--- a/Perforce.py
+++ b/Perforce.py
@@ -1009,7 +1009,7 @@ class PerforceLoginCommand(sublime_plugin.WindowCommand):
         else:
             self.pwd = self.pwd + chg
         stars = "*" * len(password)
-        self.window.show_input_panel("Project name", stars, self.on_input, self.getpwd, None)
+        self.window.show_input_panel("Enter Perforce Password", stars, self.on_input, self.getpwd, None)
 
     def on_input(self, password):
         if self.pwd.strip() == "":


### PR DESCRIPTION
Currently when a user attempts to login to Perforce via SublimeText and is prompted to enter their password it is done so in plain text. This fix resolves that by turning the users input into asterisks.
