### PR TITLE
It is not easy to use "auto checkout on save"

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -330,10 +330,10 @@ class PerforceAutoCheckout(sublime_plugin.EventListener):
         if(not perforce_settings.get('perforce_auto_checkout') or not perforce_settings.get('perforce_auto_checkout_on_save')):
             return
               
-        if(view.is_dirty()):
-            PrepareCommand();
-            success, message = Checkout(view.file_name())
-            LogResults(success, message);
+        #if(view.is_dirty()):
+        PrepareCommand();
+        success, message = Checkout(view.file_name())
+        LogResults(success, message);
 
 class PerforceCheckoutCommand(sublime_plugin.TextCommand):
     def run(self, edit):

--- a/Perforce.py
+++ b/Perforce.py
@@ -649,7 +649,7 @@ class ListCheckedOutFilesThread(threading.Thread):
                 cleanedfile = line[0:poundindex]
 
                 # just keep the filename
-                cleanedfile = '/'.join(cleanedfile.split('/')[3:])
+                # cleanedfile = '/'.join(cleanedfile.split('/')[3:])
 
                 file_entry = [cleanedfile[cleanedfile.rfind('/')+1:]]
                 file_entry.append("Changelist: " + in_changelistline[1])

--- a/Perforce.py
+++ b/Perforce.py
@@ -292,8 +292,8 @@ def IsFileWritable(in_filename):
 
 # Checkout section
 def Checkout(in_filename):
-    if(IsFileWritable(in_filename)):
-        return -1, "File is already writable."
+    # if(IsFileWritable(in_filename)):
+    #     return -1, "File is already writable."
 
     folder_name, filename = os.path.split(in_filename)
     isInDepot = IsFileInDepot(folder_name, filename)


### PR DESCRIPTION
In most satuation I want to checkout some file on save, it always prompts "Overwrite write-protected file" cause the file is read-only before checkout. If I choose "Overwirte" then the file will be writable but our plugin will not checkout this file I got a warning "the file is already writable".  So I thought "auto checkout on save" actually doesn't work.
I remove the code that check the file is writable and it will be checkout everytime I saving the file. Anyway for now it works well for me.
I do the same thing in the sublime text 3.
